### PR TITLE
MAJOR BUG FIX - Added Cache Busting

### DIFF
--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -10,6 +10,7 @@ from app.core.config import settings
 from PIL.TiffImagePlugin import IFDRational
 from geopy.geocoders import Nominatim
 from geopy.exc import GeocoderTimedOut, GeocoderServiceError
+import hashlib
 
 # Register HEIC support (More images to be supported in later updates of Haven)
 register_heif_opener()
@@ -191,10 +192,10 @@ def ensure_thumbnail(file_path: str, filename: str) -> str:
     # Ensure thumbnail directory exists
     ensure_thumbnail_dir()
 
-    # Create output filename (e.g., thumb_IMG_1234.jpg)
-    # rsplit removes the extension safely
-    name_part = filename.rsplit('.', 1)[0]
-    thumb_filename = f"thumb_{name_part}.jpg"
+    # --- Generate Unique Hash based on Full Path ---
+    # This ensures /folderA/img.jpg and /folderB/img.jpg get different thumbnails
+    path_hash = hashlib.md5(file_path.encode('utf-8')).hexdigest()
+    thumb_filename = f"thumb_{path_hash}.jpg"
     thumb_path = os.path.join(THUMBNAIL_DIR, thumb_filename)
     
     # If it already exists, we are good

--- a/backend/tests/test_images.py
+++ b/backend/tests/test_images.py
@@ -374,10 +374,11 @@ class TestGetThumbnailEndpoint:
         
         response = client.get(f"/api/v1/images/thumbnail/{test_image.id}")
         
-        # Should serve the thumbnail
+        # Should serve the thumbnail (hash-based filename)
         mock_file_response.assert_called_once()
         call_args = mock_file_response.call_args[0][0]
-        assert "thumb_photo.jpg" in call_args
+        assert "thumb_" in call_args
+        assert call_args.endswith(".jpg")
 
     @patch('app.api.v1.endpoints.images.os.path.exists')
     @patch('app.api.v1.endpoints.images.FileResponse')
@@ -418,6 +419,7 @@ class TestGetThumbnailEndpoint:
         
         response = client.get(f"/api/v1/images/thumbnail/{heic_image.id}")
         
-        # Thumbnail should be .jpg even though source is .heic
+        # Thumbnail should be .jpg even though source is .heic (hash-based filename)
         call_args = mock_file_response.call_args[0][0]
-        assert "thumb_photo.jpg" in call_args
+        assert "thumb_" in call_args
+        assert call_args.endswith(".jpg")


### PR DESCRIPTION
This pull request updates the image thumbnail generation and retrieval system to use hash-based filenames instead of names derived from the original image filename. This approach ensures that thumbnails are uniquely identified even if images from different directories share the same name. The change is applied consistently across the backend API, services, and tests. Additionally, API endpoints that return image lists or search results now include headers to prevent caching, ensuring clients always receive the most up-to-date data.

**Hash-based thumbnail and image URL generation:**

- All thumbnail filenames are now generated using an MD5 hash of the image's full file path (e.g., `thumb_<hash>.jpg`), ensuring uniqueness for images with the same name in different directories. This affects both the backend service that creates thumbnails and the API endpoints that serve or reference them. [[1]](diffhunk://#diff-c7cfff6b4686166b5dbea98434e7fd12bd10b71fce5a3b28df5b87fdff6169c1L61-R79) [[2]](diffhunk://#diff-c7cfff6b4686166b5dbea98434e7fd12bd10b71fce5a3b28df5b87fdff6169c1L146-R153) [[3]](diffhunk://#diff-0fdd77a384734bd15ca00cb2d88d8ec4f6c058edb5e6bdcc78249445945fe7f6L194-R198) [[4]](diffhunk://#diff-e7c0a042ab15d2e6b915acbca28bf58c62094e6642a4b358cb5d8f35e377569aR54-L45)

- The API responses for image lists and search results now return `thumbnail_url` and `image_url` fields that use the hash-based naming scheme. [[1]](diffhunk://#diff-c7cfff6b4686166b5dbea98434e7fd12bd10b71fce5a3b28df5b87fdff6169c1L61-R79) [[2]](diffhunk://#diff-e7c0a042ab15d2e6b915acbca28bf58c62094e6642a4b358cb5d8f35e377569aR54-L45)

**API response cache control:**

- The `get_images` and `search_photos` API endpoints now set HTTP headers to disable caching of their JSON responses, ensuring clients always receive fresh data. [[1]](diffhunk://#diff-c7cfff6b4686166b5dbea98434e7fd12bd10b71fce5a3b28df5b87fdff6169c1L61-R79) [[2]](diffhunk://#diff-e7c0a042ab15d2e6b915acbca28bf58c62094e6642a4b358cb5d8f35e377569aR24-R29)

**Testing updates:**

- All relevant tests have been updated to expect hash-based thumbnail filenames rather than names derived from the original image filename. Assertions now check for the correct filename pattern and extension. [[1]](diffhunk://#diff-e06d4ad0ff897d629074a8b7ce3be88ac8efeaab4fcfc336b97eeb8535715998L377-R381) [[2]](diffhunk://#diff-e06d4ad0ff897d629074a8b7ce3be88ac8efeaab4fcfc336b97eeb8535715998L421-R425) [[3]](diffhunk://#diff-319549e411a7e07bf5ee3fdcc1f5385af5c3837b625a5dae2d846d4994fca29bL330-R340) [[4]](diffhunk://#diff-319549e411a7e07bf5ee3fdcc1f5385af5c3837b625a5dae2d846d4994fca29bL356-R368) [[5]](diffhunk://#diff-319549e411a7e07bf5ee3fdcc1f5385af5c3837b625a5dae2d846d4994fca29bL382-R396)

- Additional test improvements include mocking the location extraction function and updating return values and assertions to match the new thumbnail filename scheme. [[1]](diffhunk://#diff-319549e411a7e07bf5ee3fdcc1f5385af5c3837b625a5dae2d846d4994fca29bR111-R124) [[2]](diffhunk://#diff-319549e411a7e07bf5ee3fdcc1f5385af5c3837b625a5dae2d846d4994fca29bR215-R227) [[3]](diffhunk://#diff-319549e411a7e07bf5ee3fdcc1f5385af5c3837b625a5dae2d846d4994fca29bR257-R267) [[4]](diffhunk://#diff-319549e411a7e07bf5ee3fdcc1f5385af5c3837b625a5dae2d846d4994fca29bR288-R290) [[5]](diffhunk://#diff-319549e411a7e07bf5ee3fdcc1f5385af5c3837b625a5dae2d846d4994fca29bR304-R306)

These changes improve the reliability and consistency of thumbnail management, prevent cache-related issues in the frontend, and ensure robust test coverage for the new logic.