### PR TITLE
Minor Update - Added more image extensions

### DIFF
--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -4,7 +4,7 @@ from app.models import Image
 from app.tasks import task_process_image, task_process_video, task_process_raw
 
 # Define extensions for routing
-IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.heic', '.webp'}
+IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.gif', '.webp', '.avif', '.bmp', '.tiff', '.tif', '.heic', '.heif'}
 VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv'}
 RAW_EXTS   = {'.arw', '.cr2', '.nef', '.dng'}
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,7 @@ psycopg2-binary==2.9.9
 pgvector==0.2.4
 pydantic-settings==2.1.0
 pillow-heif==1.1.1
+pillow-avif-plugin==1.4.3
 sentence-transformers==5.2.0
 geopy==2.4.1
 


### PR DESCRIPTION
This pull request expands support for image file formats in the scanner service and adds a new dependency to handle AVIF images. The main changes are grouped below:

Image format support:

* Extended the `IMAGE_EXTS` set in `scanner.py` to include `.gif`, `.avif`, `.bmp`, `.tiff`, `.tif`, and `.heif`, allowing the scanner to recognize and process a wider variety of image file types.

Dependency management:

* Added `pillow-avif-plugin==1.4.3` to `requirements.txt` to enable AVIF image processing support in the backend.