### PR TITLE
Issue - 38

### DIFF
--- a/frontend/src/components/RawImageViewer.jsx
+++ b/frontend/src/components/RawImageViewer.jsx
@@ -1,5 +1,5 @@
 import { X, ChevronLeft, ChevronRight, Calendar, MapPin, Info, Heart, Share2, Download, Trash2, ZoomIn, ZoomOut, HardDrive, Maximize, Camera, Aperture, Layers, Clock, MoreVertical, Play, Edit, RotateCcw, RotateCw, FolderPlus, FileType, Focus } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTheme } from '../contexts/ThemeContext';
 import { api } from '../api';
@@ -19,7 +19,44 @@ const RawImageViewer = ({ rawImage, onClose, onNext, onPrev, currentIndex, total
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
   const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
+  const [shouldLoadMedia, setShouldLoadMedia] = useState(false);
   
+  // Refs for cancelling in-flight image loads
+  const thumbnailRef = useRef(null);
+  const previewImageRef = useRef(null);
+  
+  // --- DEBOUNCE MEDIA LOADING TO PREVENT QUEUE BUILDUP ---
+  useEffect(() => {
+    if (!rawImage) return;
+
+    // Cancel any in-flight image loads by clearing the src
+    if (thumbnailRef.current) {
+      thumbnailRef.current.src = '';
+    }
+    if (previewImageRef.current) {
+      previewImageRef.current.src = '';
+    }
+
+    // Reset media loading state immediately on navigation
+    setShouldLoadMedia(false);
+
+    // Delay media loading by 150ms - if user navigates again, this gets cancelled
+    const mediaLoadTimer = setTimeout(() => {
+      setShouldLoadMedia(true);
+    }, 150);
+
+    return () => {
+      clearTimeout(mediaLoadTimer);
+      // Final cleanup: cancel any pending image loads
+      if (thumbnailRef.current) {
+        thumbnailRef.current.src = '';
+      }
+      if (previewImageRef.current) {
+        previewImageRef.current.src = '';
+      }
+    };
+  }, [rawImage]);
+
   // --- FETCH DETAILS LOGIC ---
   useEffect(() => {
     if (!rawImage) return;
@@ -255,6 +292,7 @@ const RawImageViewer = ({ rawImage, onClose, onNext, onPrev, currentIndex, total
                   {/* Thumbnail - shown immediately */}
                   {!imageLoaded && (
                     <motion.img 
+                      ref={thumbnailRef}
                       initial={{ opacity: 0 }}
                       animate={{ opacity: 1 }}
                       style={{willChange: 'opacity'}}
@@ -266,17 +304,20 @@ const RawImageViewer = ({ rawImage, onClose, onNext, onPrev, currentIndex, total
                   )}
                   
                   {/* Preview image (JPEG converted) */}
-                  <motion.img 
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: imageLoaded ? 1 : 0 }}
-                    transition={{ duration: 0.3 }}
-                    src={api.getRawPreviewUrl(activeRawImage.id)}
-                    alt={activeRawImage.filename}
-                    onLoad={() => setImageLoaded(true)}
-                    className="max-h-[80vh] max-w-full object-contain rounded-2xl shadow-2xl select-none"
-                    style={{ display: imageLoaded ? 'block' : 'none', willChange: 'opacity, transform' }}
-                    draggable={false}
-                  />
+                  {shouldLoadMedia && (
+                    <motion.img 
+                      ref={previewImageRef}
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: imageLoaded ? 1 : 0 }}
+                      transition={{ duration: 0.3 }}
+                      src={api.getRawPreviewUrl(activeRawImage.id)}
+                      alt={activeRawImage.filename}
+                      onLoad={() => setImageLoaded(true)}
+                      className="max-h-[80vh] max-w-full object-contain rounded-2xl shadow-2xl select-none"
+                      style={{ display: imageLoaded ? 'block' : 'none', willChange: 'opacity, transform' }}
+                      draggable={false}
+                    />
+                  )}
                 </motion.div>
               </AnimatePresence>
             </div>


### PR DESCRIPTION
This pull request introduces a debounced media loading mechanism to the `ImageViewer`, `RawImageViewer`, and `VideoViewer` components. The main goal is to prevent unnecessary network requests and reduce resource usage when users rapidly navigate between media items. This is achieved by delaying the loading of images and videos by 150ms and canceling in-flight loads if navigation occurs again within that window. The implementation uses React refs to manage and cancel media loads, and conditionally renders media elements only when loading should proceed.

**Debounced Media Loading for All Viewers:**

* Added a 150ms debounce before loading full-resolution images and videos in `ImageViewer`, `RawImageViewer`, and `VideoViewer`, canceling any in-flight loads if the user navigates again within that period. This reduces unnecessary network requests and improves performance when quickly browsing media. [[1]](diffhunk://#diff-0111b7fa332706b0448529b12229d8553fe3879b0b16c603a2c5b916918c4ff2R24-R60) [[2]](diffhunk://#diff-d439259b7fd477ee03603401668fab4aa41a8dad41e81802075d4b2e9bc230a3R22-R58) [[3]](diffhunk://#diff-f7d9fef123fa83ace404719aa6a4320c780e78415ab9b56b6c69c6773ae10a65R34-R70)

**Image and Raw Image Viewer Improvements:**

* Introduced `useRef` hooks (`thumbnailRef`, `fullImageRef`, `previewImageRef`) to allow canceling of in-flight image loads by clearing the `src` attribute during navigation or unmount. [[1]](diffhunk://#diff-0111b7fa332706b0448529b12229d8553fe3879b0b16c603a2c5b916918c4ff2R24-R60) [[2]](diffhunk://#diff-d439259b7fd477ee03603401668fab4aa41a8dad41e81802075d4b2e9bc230a3R22-R58)
* Modified rendering logic to only display the full-size or preview images when `shouldLoadMedia` is true, ensuring that large images are not loaded unnecessarily. [[1]](diffhunk://#diff-0111b7fa332706b0448529b12229d8553fe3879b0b16c603a2c5b916918c4ff2R317-R319) [[2]](diffhunk://#diff-0111b7fa332706b0448529b12229d8553fe3879b0b16c603a2c5b916918c4ff2R330) [[3]](diffhunk://#diff-d439259b7fd477ee03603401668fab4aa41a8dad41e81802075d4b2e9bc230a3R307-R309) [[4]](diffhunk://#diff-d439259b7fd477ee03603401668fab4aa41a8dad41e81802075d4b2e9bc230a3R320)
* Passed refs to thumbnail images to enable proper cancellation. [[1]](diffhunk://#diff-0111b7fa332706b0448529b12229d8553fe3879b0b16c603a2c5b916918c4ff2R305) [[2]](diffhunk://#diff-d439259b7fd477ee03603401668fab4aa41a8dad41e81802075d4b2e9bc230a3R295)

**Video Viewer Improvements:**

* Used a debounce for video loading, including canceling and resetting the video element's source and playback state on navigation.
* Changed the `src` attribute of the `<video>` element to only be set when `shouldLoadMedia` is true, preventing unnecessary video loads.
* Reset the video duration state when navigating to the next or previous video to ensure correct UI updates.

These changes collectively make the media viewers more efficient and responsive, especially when users navigate quickly through large sets of images or videos.

Fixes #38 