### PR TITLE
PyTests - Updated tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 import sys
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, Column, Integer, String, DateTime, Float, Boolean, PickleType
+from sqlalchemy.sql import text
 from sqlalchemy.orm import sessionmaker, declarative_base
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql import func
@@ -36,6 +37,7 @@ class Image(TestBase):
 
     id = Column(Integer, primary_key=True, index=True)
     filename = Column(String, index=True)
+    is_favorite = Column(Boolean, default=False, server_default=text("FALSE"))
     file_path = Column(String, unique=True, index=True)  # Added for test compatibility
     file_size = Column(Integer)
     capture_date = Column(DateTime(timezone=True), server_default=func.now())
@@ -144,6 +146,7 @@ def sample_image_data():
     """
     return {
         "filename": "test_beach.jpg",
+        "is_favorite": False,
         "file_path": "/test/photos/test_beach.jpg",
         "file_size": 2048576,
         "latitude": 37.775,
@@ -161,6 +164,7 @@ def sample_images(db_session):
         Image(
             filename="beach.jpg",
             file_path="/test/beach.jpg",
+            is_favorite=False,
             file_size=1024000,
             width=4000,
             height=3000,
@@ -181,6 +185,7 @@ def sample_images(db_session):
         Image(
             filename="mountain.jpg",
             file_path="/test/mountain.jpg",
+            is_favorite=False,
             file_size=2048000,
             width=3840,
             height=2160,
@@ -201,6 +206,7 @@ def sample_images(db_session):
         Image(
             filename="city.heic",
             file_path="/test/city.heic",
+            is_favorite=False,
             file_size=3072000,
             width=4032,
             height=3024,

--- a/backend/tests/test_images.py
+++ b/backend/tests/test_images.py
@@ -316,48 +316,6 @@ class TestGetTimelineEndpoint:
             assert "date" in image
             assert "metadata" in image
 
-
-class TestGetMapDataEndpoint:
-    """Test suite for GET /api/v1/images/map-data endpoint"""
-
-    def test_get_map_data_empty(self, client, db_session):
-        """Test map data with no geotagged images"""
-        response = client.get("/api/v1/images/map-data")
-        
-        assert response.status_code == status.HTTP_200_OK
-        data = response.json()
-        assert isinstance(data, list)
-
-    def test_get_map_data_with_geotagged_images(self, client, sample_images, db_session):
-        """Test map data returns only geotagged images"""
-        response = client.get("/api/v1/images/map-data")
-        
-        assert response.status_code == status.HTTP_200_OK
-        data = response.json()
-        assert isinstance(data, list)
-        
-        # All returned images should have GPS coordinates
-        for point in data:
-            assert "latitude" in point
-            assert "longitude" in point
-            assert point["latitude"] is not None
-            assert point["longitude"] is not None
-            assert "thumbnail_url" in point
-
-    def test_get_map_data_structure(self, client, sample_images, db_session):
-        """Test map data response structure"""
-        response = client.get("/api/v1/images/map-data")
-        
-        assert response.status_code == status.HTTP_200_OK
-        data = response.json()
-        
-        if len(data) > 0:
-            point = data[0]
-            required_fields = ["id", "latitude", "longitude", "thumbnail_url"]
-            for field in required_fields:
-                assert field in point
-
-
 class TestGetThumbnailEndpoint:
     """Test suite for GET /api/v1/images/thumbnail/{image_id} endpoint"""
 


### PR DESCRIPTION
This pull request updates the test database model and test data for images to include an `is_favorite` boolean field, ensuring compatibility with recent changes to the application schema. Additionally, it removes the test suite for the `/api/v1/images/map-data` endpoint from `test_images.py`. The most important changes are grouped below:

**Test database model and fixtures update:**

* Added an `is_favorite` boolean column to the `Image` model in `conftest.py`, with a default value of `False` and a server default of `FALSE` for database compatibility.
* Updated all image test data in `conftest.py` (`sample_image_data` and `sample_images`) to explicitly set `is_favorite=False`. [[1]](diffhunk://#diff-aacea3e16f9fecd307f1a11567ba7a1abb8a6007266aec3b89dd65454130b76cR149) [[2]](diffhunk://#diff-aacea3e16f9fecd307f1a11567ba7a1abb8a6007266aec3b89dd65454130b76cR167) [[3]](diffhunk://#diff-aacea3e16f9fecd307f1a11567ba7a1abb8a6007266aec3b89dd65454130b76cR188) [[4]](diffhunk://#diff-aacea3e16f9fecd307f1a11567ba7a1abb8a6007266aec3b89dd65454130b76cR209)

**Test suite removal:**

* Removed the entire `TestGetMapDataEndpoint` test class and its associated tests from `test_images.py`, which previously tested the `/api/v1/images/map-data` endpoint.

**Dependency update:**

* Imported `text` from `sqlalchemy.sql` in `conftest.py` to support the new server default for the `is_favorite` column.