### PR TITLE
Added Filter Pills in Favorites and Albums

### DIFF
--- a/backend/app/api/v1/endpoints/albums.py
+++ b/backend/app/api/v1/endpoints/albums.py
@@ -517,6 +517,7 @@ def get_album_timeline(
     albumId: int,
     skip: int = 0, 
     limit: int = 500,
+    mediaFilter: str = "all",
     db: Session = Depends(get_db)
 ):
     response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
@@ -555,7 +556,16 @@ def get_album_timeline(
     base_query = db.query(combined_query).filter(combined_query.c.album_ids.contains([albumId]))
     
     # Calculate total count BEFORE applying offset/limit
-    total_count = base_query.count()
+    if mediaFilter == "all":
+        total_count = base_query.count()
+    elif mediaFilter == "videos":
+        total_count = base_query.filter(combined_query.c.type == "video").count()
+    elif mediaFilter == "raw":
+        total_count = base_query.filter(combined_query.c.type == "raw").count()
+    elif mediaFilter == "photos":
+        total_count = base_query.filter(combined_query.c.type == "image").count()
+    else:
+        total_count = 0
     response.headers["X-Total-Count"] = str(total_count)
 
     # Sort by Date DESC and apply pagination
@@ -619,7 +629,8 @@ def get_album_timeline(
 
         output.append(item)
 
-    return [
+    if mediaFilter == "all":
+        return [
         {
             "id": item["id"],
             "filename": item["filename"],
@@ -660,6 +671,137 @@ def get_album_timeline(
         }
         for item in output
     ]
+    elif mediaFilter == "videos":
+        return [
+        {
+            "id": item["id"],
+            "filename": item["filename"],
+            "is_favorite": item["is_favorite"],
+            "type": item["type"],
+            "extension": item["extension"],
+            "thumbnail_url": item["thumbnail_url"],
+            "preview_url": item["preview_url"] if item["type"] == "raw" or item["type"] == "video" else None,
+            "image_url": item["image_url"] if item["type"] == "image" else None,
+            "video_url": item["video_url"] if item["type"] == "video" else None,
+            "raw_url": item["raw_url"] if item["type"] == "raw" else None,
+            "date": item["capture_date"],
+            "latitude": item["latitude"],
+            "longitude": item["longitude"],
+            "city": item["city"],
+            "state": item["state"],
+            "country": item["country"],
+            "width": item["width"],
+            "height": item["height"],
+            "duration": item["duration"],
+            "megapixels": item["megapixels"],
+            "metadata": {
+                "camera_make": item["camera_make"],
+                "camera_model": item["camera_model"],
+                "lens_make": item["lens_make"],
+                "lens_model": item["lens_model"],
+                "exposure_time": item["exposure_time"],
+                "f_number": item["f_number"],
+                "iso": item["iso"],
+                "focal_length": item["focal_length"],
+                "flash_fired": item["flash_fired"],
+                "size_bytes": item["file_size"],
+                "fps": item["fps"],
+                "codec": item["codec"],
+                "width": item["width"],
+                "height": item["height"],
+            }
+        }
+        for item in output if item["type"] == "video"
+    ]
+
+    elif mediaFilter == "raw":
+        return [
+        {
+            "id": item["id"],
+            "filename": item["filename"],
+            "is_favorite": item["is_favorite"],
+            "type": item["type"],
+            "extension": item["extension"],
+            "thumbnail_url": item["thumbnail_url"],
+            "preview_url": item["preview_url"] if item["type"] == "raw" or item["type"] == "video" else None,
+            "image_url": item["image_url"] if item["type"] == "image" else None,
+            "video_url": item["video_url"] if item["type"] == "video" else None,
+            "raw_url": item["raw_url"] if item["type"] == "raw" else None,
+            "date": item["capture_date"],
+            "latitude": item["latitude"],
+            "longitude": item["longitude"],
+            "city": item["city"],
+            "state": item["state"],
+            "country": item["country"],
+            "width": item["width"],
+            "height": item["height"],
+            "duration": item["duration"],
+            "megapixels": item["megapixels"],
+            "metadata": {
+                "camera_make": item["camera_make"],
+                "camera_model": item["camera_model"],
+                "lens_make": item["lens_make"],
+                "lens_model": item["lens_model"],
+                "exposure_time": item["exposure_time"],
+                "f_number": item["f_number"],
+                "iso": item["iso"],
+                "focal_length": item["focal_length"],
+                "flash_fired": item["flash_fired"],
+                "size_bytes": item["file_size"],
+                "fps": item["fps"],
+                "codec": item["codec"],
+                "width": item["width"],
+                "height": item["height"],
+            }
+        }
+        for item in output if item["type"] == "raw"
+    ]
+    elif mediaFilter == "photos":
+        return [
+        {
+            "id": item["id"],
+            "filename": item["filename"],
+            "is_favorite": item["is_favorite"],
+            "type": item["type"],
+            "extension": item["extension"],
+            "thumbnail_url": item["thumbnail_url"],
+            "preview_url": item["preview_url"] if item["type"] == "raw" or item["type"] == "video" else None,
+            "image_url": item["image_url"] if item["type"] == "image" else None,
+            "video_url": item["video_url"] if item["type"] == "video" else None,
+            "raw_url": item["raw_url"] if item["type"] == "raw" else None,
+            "date": item["capture_date"],
+            "latitude": item["latitude"],
+            "longitude": item["longitude"],
+            "city": item["city"],
+            "state": item["state"],
+            "country": item["country"],
+            "width": item["width"],
+            "height": item["height"],
+            "duration": item["duration"],
+            "megapixels": item["megapixels"],
+            "metadata": {
+                "camera_make": item["camera_make"],
+                "camera_model": item["camera_model"],
+                "lens_make": item["lens_make"],
+                "lens_model": item["lens_model"],
+                "exposure_time": item["exposure_time"],
+                "f_number": item["f_number"],
+                "iso": item["iso"],
+                "focal_length": item["focal_length"],
+                "flash_fired": item["flash_fired"],
+                "size_bytes": item["file_size"],
+                "fps": item["fps"],
+                "codec": item["codec"],
+                "width": item["width"],
+                "height": item["height"],
+            }
+        }
+        for item in output if item["type"] == "image"
+    ]
+    else:
+        return []
+
+    
 
 @router.get("/getPartOfAlbums/{fileType}/{id}", response_model=dict)
 def get_part_of_albums(fileType: str, id: int, db: Session = Depends(get_db)):

--- a/backend/app/api/v1/endpoints/dashboard.py
+++ b/backend/app/api/v1/endpoints/dashboard.py
@@ -134,11 +134,30 @@ def get_data_breakdown(path: str):
 
 # 7. GET PROCESSED FILES INFORMATION
 @router.get("/processed_files_information", response_model=dict)
-def get_processed_files_information(path: str, db: Session = Depends(get_db)):
+def get_processed_files_information(db: Session = Depends(get_db)):
     """
     Gets the processed files information from the haven vault.
     """
-    if not path or not os.path.exists(path):
+        
+    try:
+        albums_count = db.query(models.Albums).count()
+        processed_images_count = db.query(models.Image).count()
+        processed_videos_count = db.query(models.Video).count()
+        processed_raw_count = db.query(models.RawImage).count()
+        processed_total_files_count = processed_images_count + processed_videos_count + processed_raw_count
+        images = db.query(models.Image).all()
+        videos = db.query(models.Video).all()
+        raw_images = db.query(models.RawImage).all()
+        processed_total_files_size = sum(image.file_size for image in images) + sum(video.file_size for video in videos) + sum(raw_image.file_size for raw_image in raw_images)
+        return {
+            "albums_count": albums_count,
+            "processed_images_count": processed_images_count,
+            "processed_videos_count": processed_videos_count,
+            "processed_raw_count": processed_raw_count,
+            "processed_total_files_count": processed_total_files_count,
+            "processed_total_files_size": processed_total_files_size
+        }
+    except Exception as e:
         return {
             "albums_count": None,
             "processed_images_count": None,
@@ -147,24 +166,6 @@ def get_processed_files_information(path: str, db: Session = Depends(get_db)):
             "processed_total_files_count": None,
             "processed_total_files_size": None
             }
-    
-    albums_count = db.query(models.Albums).count()
-    processed_images_count = db.query(models.Image).count()
-    processed_videos_count = db.query(models.Video).count()
-    processed_raw_count = db.query(models.RawImage).count()
-    processed_total_files_count = processed_images_count + processed_videos_count + processed_raw_count
-    images = db.query(models.Image).all()
-    videos = db.query(models.Video).all()
-    raw_images = db.query(models.RawImage).all()
-    processed_total_files_size = sum(image.file_size for image in images) + sum(video.file_size for video in videos) + sum(raw_image.file_size for raw_image in raw_images)
-    return {
-        "albums_count": albums_count,
-        "processed_images_count": processed_images_count,
-        "processed_videos_count": processed_videos_count,
-        "processed_raw_count": processed_raw_count,
-        "processed_total_files_count": processed_total_files_count,
-        "processed_total_files_size": processed_total_files_size
-    }
 
 # 8. GET METADATA INFORMATION
 @router.get("/metadata_information", response_model=dict)

--- a/backend/app/api/v1/endpoints/favorites.py
+++ b/backend/app/api/v1/endpoints/favorites.py
@@ -75,6 +75,7 @@ def get_favorites_timeline(
     response: Response,
     skip: int = 0, 
     limit: int = 100,
+    mediaFilter: str = 'all',
     db: Session = Depends(get_db)
 ):
     response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
@@ -108,7 +109,16 @@ def get_favorites_timeline(
 
     combined_query = union_all(queryImages, queryVideos, queryRawImages).alias("media_union")
 
-    total_count = db.query(combined_query).count()
+    if mediaFilter == "all":
+        total_count = db.query(combined_query).count()
+    elif mediaFilter == "videos":
+        total_count = db.query(combined_query).filter(combined_query.c.type == "video").count()
+    elif mediaFilter == "raw":
+        total_count = db.query(combined_query).filter(combined_query.c.type == "raw").count()
+    elif mediaFilter == "photos":
+        total_count = db.query(combined_query).filter(combined_query.c.type == "image").count()
+    else:
+        total_count = 0
     response.headers["X-Total-Count"] = str(total_count)
 
     # Sort by Date DESC
@@ -171,48 +181,173 @@ def get_favorites_timeline(
             item["raw_url"] = item["file_url"]
 
         output.append(item)
-
-    return [
-        {
-            "id": item["id"],
-            "filename": item["filename"],
-            "is_favorite": item["is_favorite"],
-            "type": item["type"],
-            "extension": item["extension"],
-            "thumbnail_url": item["thumbnail_url"],
-            "preview_url": item["preview_url"] if item["type"] == "raw" or item["type"] == "video" else None,
-            "image_url": item["image_url"] if item["type"] == "image" else None,
-            "video_url": item["video_url"] if item["type"] == "video" else None,
-            "raw_url": item["raw_url"] if item["type"] == "raw" else None,
-            "date": item["capture_date"],
-            "latitude": item["latitude"],
-            "longitude": item["longitude"],
-            "city": item["city"],
-            "state": item["state"],
-            "country": item["country"],
-            "width": item["width"],
-            "height": item["height"],
-            "duration": item["duration"],
-            "megapixels": item["megapixels"],
-            "metadata": {
-                "camera_make": item["camera_make"],
-                "camera_model": item["camera_model"],
-                "lens_make": item["lens_make"],
-                "lens_model": item["lens_model"],
-                "exposure_time": item["exposure_time"],
-                "f_number": item["f_number"],
-                "iso": item["iso"],
-                "focal_length": item["focal_length"],
-                "flash_fired": item["flash_fired"],
-                "size_bytes": item["file_size"],
-                "fps": item["fps"],
-                "codec": item["codec"],
-                "width": item["width"],
-                "height": item["height"],
-            }
-        }
-        for item in output
-    ]
+    if mediaFilter == "all":
+        return [
+                {
+                    "id": item["id"],
+                    "filename": item["filename"],
+                    "is_favorite": item["is_favorite"],
+                    "type": item["type"],
+                    "extension": item["extension"],
+                    "thumbnail_url": item["thumbnail_url"],
+                    "preview_url": item["preview_url"] if item["type"] == "raw" or item["type"] == "video" else None,
+                    "image_url": item["image_url"] if item["type"] == "image" else None,
+                    "video_url": item["video_url"] if item["type"] == "video" else None,
+                    "raw_url": item["raw_url"] if item["type"] == "raw" else None,
+                    "date": item["capture_date"],
+                    "latitude": item["latitude"],
+                    "longitude": item["longitude"],
+                    "city": item["city"],
+                    "state": item["state"],
+                    "country": item["country"],
+                    "width": item["width"],
+                    "height": item["height"],
+                    "duration": item["duration"],
+                    "megapixels": item["megapixels"],
+                    "metadata": {
+                        "camera_make": item["camera_make"],
+                        "camera_model": item["camera_model"],
+                        "lens_make": item["lens_make"],
+                        "lens_model": item["lens_model"],
+                        "exposure_time": item["exposure_time"],
+                        "f_number": item["f_number"],
+                        "iso": item["iso"],
+                        "focal_length": item["focal_length"],
+                        "flash_fired": item["flash_fired"],
+                        "size_bytes": item["file_size"],
+                        "fps": item["fps"],
+                        "codec": item["codec"],
+                        "width": item["width"],
+                        "height": item["height"],
+                    }
+                }
+                for item in output
+            ]
+    elif mediaFilter == "photos":
+        return [
+                {
+                    "id": item["id"],
+                    "filename": item["filename"],
+                    "is_favorite": item["is_favorite"],
+                    "type": item["type"],
+                    "extension": item["extension"],
+                    "thumbnail_url": item["thumbnail_url"],
+                    "preview_url": item["preview_url"] if item["type"] == "raw" or item["type"] == "video" else None,
+                    "image_url": item["image_url"] if item["type"] == "image" else None,
+                    "video_url": item["video_url"] if item["type"] == "video" else None,
+                    "raw_url": item["raw_url"] if item["type"] == "raw" else None,
+                    "date": item["capture_date"],
+                    "latitude": item["latitude"],
+                    "longitude": item["longitude"],
+                    "city": item["city"],
+                    "state": item["state"],
+                    "country": item["country"],
+                    "width": item["width"],
+                    "height": item["height"],
+                    "duration": item["duration"],
+                    "megapixels": item["megapixels"],
+                    "metadata": {
+                        "camera_make": item["camera_make"],
+                        "camera_model": item["camera_model"],
+                        "lens_make": item["lens_make"],
+                        "lens_model": item["lens_model"],
+                        "exposure_time": item["exposure_time"],
+                        "f_number": item["f_number"],
+                        "iso": item["iso"],
+                        "focal_length": item["focal_length"],
+                        "flash_fired": item["flash_fired"],
+                        "size_bytes": item["file_size"],
+                        "fps": item["fps"],
+                        "codec": item["codec"],
+                        "width": item["width"],
+                        "height": item["height"],
+                    }
+                } for item in output if item["type"] == "image"
+            ]
+    elif mediaFilter == "videos":
+        return [
+                {
+                    "id": item["id"],
+                    "filename": item["filename"],
+                    "is_favorite": item["is_favorite"],
+                    "type": item["type"],
+                    "extension": item["extension"],
+                    "thumbnail_url": item["thumbnail_url"],
+                    "preview_url": item["preview_url"] if item["type"] == "raw" or item["type"] == "video" else None,
+                    "image_url": item["image_url"] if item["type"] == "image" else None,
+                    "video_url": item["video_url"] if item["type"] == "video" else None,
+                    "raw_url": item["raw_url"] if item["type"] == "raw" else None,
+                    "date": item["capture_date"],
+                    "latitude": item["latitude"],
+                    "longitude": item["longitude"],
+                    "city": item["city"],
+                    "state": item["state"],
+                    "country": item["country"],
+                    "width": item["width"],
+                    "height": item["height"],
+                    "duration": item["duration"],
+                    "megapixels": item["megapixels"],
+                    "metadata": {
+                        "camera_make": item["camera_make"],
+                        "camera_model": item["camera_model"],
+                        "lens_make": item["lens_make"],
+                        "lens_model": item["lens_model"],
+                        "exposure_time": item["exposure_time"],
+                        "f_number": item["f_number"],
+                        "iso": item["iso"],
+                        "focal_length": item["focal_length"],
+                        "flash_fired": item["flash_fired"],
+                        "size_bytes": item["file_size"],
+                        "fps": item["fps"],
+                        "codec": item["codec"],
+                        "width": item["width"],
+                        "height": item["height"],
+                    }
+                } for item in output if item["type"] == "video"
+            ]
+    elif mediaFilter == "raw":
+        return [
+                {
+                    "id": item["id"],
+                    "filename": item["filename"],
+                    "is_favorite": item["is_favorite"],
+                    "type": item["type"],
+                    "extension": item["extension"],
+                    "thumbnail_url": item["thumbnail_url"],
+                    "preview_url": item["preview_url"] if item["type"] == "raw" or item["type"] == "video" else None,
+                    "image_url": item["image_url"] if item["type"] == "image" else None,
+                    "video_url": item["video_url"] if item["type"] == "video" else None,
+                    "raw_url": item["raw_url"] if item["type"] == "raw" else None,
+                    "date": item["capture_date"],
+                    "latitude": item["latitude"],
+                    "longitude": item["longitude"],
+                    "city": item["city"],
+                    "state": item["state"],
+                    "country": item["country"],
+                    "width": item["width"],
+                    "height": item["height"],
+                    "duration": item["duration"],
+                    "megapixels": item["megapixels"],
+                    "metadata": {
+                        "camera_make": item["camera_make"],
+                        "camera_model": item["camera_model"],
+                        "lens_make": item["lens_make"],
+                        "lens_model": item["lens_model"],
+                        "exposure_time": item["exposure_time"],
+                        "f_number": item["f_number"],
+                        "iso": item["iso"],
+                        "focal_length": item["focal_length"],
+                        "flash_fired": item["flash_fired"],
+                        "size_bytes": item["file_size"],
+                        "fps": item["fps"],
+                        "codec": item["codec"],
+                        "width": item["width"],
+                        "height": item["height"],
+                    }
+                } for item in output if item["type"] == "raw"
+            ]
+    else:
+        return []
 
 @router.post("/toggle/{fileType}/{id}", response_model=int)
 def toggle_favorite(id: int, fileType: str, db: Session = Depends(get_db)):

--- a/backend/app/api/v1/endpoints/intelligence.py
+++ b/backend/app/api/v1/endpoints/intelligence.py
@@ -482,7 +482,7 @@ def search_all_media(response: Response, query: str, threshold: float = 0.8, ski
     ]
 
 @router.post("/search/favorites")
-def search_favorites(response: Response, query: str, threshold: float = 0.8, skip: int=0, limit: int=500, db: Session = Depends(get_db)):
+def search_favorites(response: Response, query: str, threshold: float = 0.8, skip: int=0, limit: int=500, mediaFilter="all", db: Session = Depends(get_db)):
     """
     Finds favorites based on semantic similarity.
     
@@ -539,7 +539,16 @@ def search_favorites(response: Response, query: str, threshold: float = 0.8, ski
     )
     
     # 2. Get Count and set header
-    total_match_count = base_query.count()
+    if mediaFilter == "all":
+        total_match_count = base_query.count()
+    elif mediaFilter == "videos":
+        total_match_count = base_query.filter(combined_query.c.type == "video").count()
+    elif mediaFilter == "raw":
+        total_match_count = base_query.filter(combined_query.c.type == "raw").count()
+    elif mediaFilter == "photos":
+        total_match_count = base_query.filter(combined_query.c.type == "image").count()
+    else:
+        total_match_count = 0
     response.headers["X-Total-Count"] = str(total_match_count)
 
     # 3. Use Cosine Distance operator (<=>)
@@ -601,7 +610,8 @@ def search_favorites(response: Response, query: str, threshold: float = 0.8, ski
 
         output.append(item)
 
-    return [
+    if mediaFilter == "all":
+        return [
         {
             "id": item["id"],
             "score": item["score"],
@@ -642,8 +652,139 @@ def search_favorites(response: Response, query: str, threshold: float = 0.8, ski
             }
         }
         for item in output
-    ]
+        ]
+    elif mediaFilter == "videos":
+        return [
+        {
+            "id": item["id"],
+            "score": item["score"],
+            "filename": item["filename"],
+            "is_favorite": item["is_favorite"],
+            "type": item["type"],
+            "extension": item["extension"],
+            "thumbnail_url": item["thumbnail_url"],
+            "preview_url": item["preview_url"] if item["type"] == "raw" or item["type"] == "video" else None,
+            "image_url": item["image_url"] if item["type"] == "image" else None,
+            "video_url": item["video_url"] if item["type"] == "video" else None,
+            "raw_url": item["raw_url"] if item["type"] == "raw" else None,
+            "date": item["capture_date"],
+            "latitude": item["latitude"],
+            "longitude": item["longitude"],
+            "city": item["city"],
+            "state": item["state"],
+            "country": item["country"],
+            "width": item["width"],
+            "height": item["height"],
+            "duration": item["duration"],
+            "megapixels": item["megapixels"],
+            "metadata": {
+                "camera_make": item["camera_make"],
+                "camera_model": item["camera_model"],
+                "lens_make": item["lens_make"],
+                "lens_model": item["lens_model"],
+                "exposure_time": item["exposure_time"],
+                "f_number": item["f_number"],
+                "iso": item["iso"],
+                "focal_length": item["focal_length"],
+                "flash_fired": item["flash_fired"],
+                "size_bytes": item["file_size"],
+                "fps": item["fps"],
+                "codec": item["codec"],
+                "width": item["width"],
+                "height": item["height"],
+            }
+        }
+        for item in output if item["type"] == "video"
+        ]
 
+    elif mediaFilter == "raw":
+        return [
+        {
+            "id": item["id"],
+            "score": item["score"],
+            "filename": item["filename"],
+            "is_favorite": item["is_favorite"],
+            "type": item["type"],
+            "extension": item["extension"],
+            "thumbnail_url": item["thumbnail_url"],
+            "preview_url": item["preview_url"] if item["type"] == "raw" or item["type"] == "video" else None,
+            "image_url": item["image_url"] if item["type"] == "image" else None,
+            "video_url": item["video_url"] if item["type"] == "video" else None,
+            "raw_url": item["raw_url"] if item["type"] == "raw" else None,
+            "date": item["capture_date"],
+            "latitude": item["latitude"],
+            "longitude": item["longitude"],
+            "city": item["city"],
+            "state": item["state"],
+            "country": item["country"],
+            "width": item["width"],
+            "height": item["height"],
+            "duration": item["duration"],
+            "megapixels": item["megapixels"],
+            "metadata": {
+                "camera_make": item["camera_make"],
+                "camera_model": item["camera_model"],
+                "lens_make": item["lens_make"],
+                "lens_model": item["lens_model"],
+                "exposure_time": item["exposure_time"],
+                "f_number": item["f_number"],
+                "iso": item["iso"],
+                "focal_length": item["focal_length"],
+                "flash_fired": item["flash_fired"],
+                "size_bytes": item["file_size"],
+                "fps": item["fps"],
+                "codec": item["codec"],
+                "width": item["width"],
+                "height": item["height"],
+            }
+        }
+        for item in output if item["type"] == "raw"
+        ]
+    elif mediaFilter == "photos":
+        return [
+        {
+            "id": item["id"],
+            "score": item["score"],
+            "filename": item["filename"],
+            "is_favorite": item["is_favorite"],
+            "type": item["type"],
+            "extension": item["extension"],
+            "thumbnail_url": item["thumbnail_url"],
+            "preview_url": item["preview_url"] if item["type"] == "raw" or item["type"] == "video" else None,
+            "image_url": item["image_url"] if item["type"] == "image" else None,
+            "video_url": item["video_url"] if item["type"] == "video" else None,
+            "raw_url": item["raw_url"] if item["type"] == "raw" else None,
+            "date": item["capture_date"],
+            "latitude": item["latitude"],
+            "longitude": item["longitude"],
+            "city": item["city"],
+            "state": item["state"],
+            "country": item["country"],
+            "width": item["width"],
+            "height": item["height"],
+            "duration": item["duration"],
+            "megapixels": item["megapixels"],
+            "metadata": {
+                "camera_make": item["camera_make"],
+                "camera_model": item["camera_model"],
+                "lens_make": item["lens_make"],
+                "lens_model": item["lens_model"],
+                "exposure_time": item["exposure_time"],
+                "f_number": item["f_number"],
+                "iso": item["iso"],
+                "focal_length": item["focal_length"],
+                "flash_fired": item["flash_fired"],
+                "size_bytes": item["file_size"],
+                "fps": item["fps"],
+                "codec": item["codec"],
+                "width": item["width"],
+                "height": item["height"],
+            }
+        }
+        for item in output if item["type"] == "image"
+        ]
+    else:
+        return []
 
 @router.post("/search/map/images", response_model=List[dict])
 def search_map_points_images(
@@ -889,7 +1030,7 @@ def search_map_points_all_media(
     return response
 
 @router.post("/search/albums/{albumId}")
-def search_albums(response: Response, albumId: int, query: str, threshold: float = 0.8, skip: int=0, limit: int=500, db: Session = Depends(get_db)):
+def search_albums(response: Response, albumId: int, query: str, threshold: float = 0.8, skip: int=0, limit: int=500, mediaFilter="all", db: Session = Depends(get_db)):
     """
     Finds all media based on semantic similarity.
     
@@ -946,7 +1087,16 @@ def search_albums(response: Response, albumId: int, query: str, threshold: float
     ).filter(combined_query.c.album_ids.contains([albumId]))
     
     # 2. Get Count and set header
-    total_match_count = base_query.count()
+    if mediaFilter == "all":
+        total_match_count = base_query.count()
+    elif mediaFilter == "videos":
+        total_match_count = base_query.filter(combined_query.c.type == "video").count()
+    elif mediaFilter == "raw":
+        total_match_count = base_query.filter(combined_query.c.type == "raw").count()
+    elif mediaFilter == "photos":
+        total_match_count = base_query.filter(combined_query.c.type == "image").count()
+    else:
+        total_match_count = 0
     response.headers["X-Total-Count"] = str(total_match_count)
 
     # 3. Use Cosine Distance operator (<=>)
@@ -1008,7 +1158,8 @@ def search_albums(response: Response, albumId: int, query: str, threshold: float
 
         output.append(item)
 
-    return [
+    if mediaFilter == "all":
+        return [
         {
             "id": item["id"],
             "score": item["score"],
@@ -1050,3 +1201,134 @@ def search_albums(response: Response, albumId: int, query: str, threshold: float
         }
         for item in output
     ]
+    elif mediaFilter == "videos":
+        return [
+        {
+            "id": item["id"],
+            "score": item["score"],
+            "filename": item["filename"],
+            "is_favorite": item["is_favorite"],
+            "type": item["type"],
+            "extension": item["extension"],
+            "thumbnail_url": item["thumbnail_url"],
+            "preview_url": item["preview_url"] if item["type"] == "raw" or item["type"] == "video" else None,
+            "image_url": item["image_url"] if item["type"] == "image" else None,
+            "video_url": item["video_url"] if item["type"] == "video" else None,
+            "raw_url": item["raw_url"] if item["type"] == "raw" else None,
+            "date": item["capture_date"],
+            "latitude": item["latitude"],
+            "longitude": item["longitude"],
+            "city": item["city"],
+            "state": item["state"],
+            "country": item["country"],
+            "width": item["width"],
+            "height": item["height"],
+            "duration": item["duration"],
+            "megapixels": item["megapixels"],
+            "metadata": {
+                "camera_make": item["camera_make"],
+                "camera_model": item["camera_model"],
+                "lens_make": item["lens_make"],
+                "lens_model": item["lens_model"],
+                "exposure_time": item["exposure_time"],
+                "f_number": item["f_number"],
+                "iso": item["iso"],
+                "focal_length": item["focal_length"],
+                "flash_fired": item["flash_fired"],
+                "size_bytes": item["file_size"],
+                "fps": item["fps"],
+                "codec": item["codec"],
+                "width": item["width"],
+                "height": item["height"],
+            }
+        }
+        for item in output if item["type"] == "video"
+    ]
+    elif mediaFilter == "raw":
+        return [
+        {
+            "id": item["id"],
+            "score": item["score"],
+            "filename": item["filename"],
+            "is_favorite": item["is_favorite"],
+            "type": item["type"],
+            "extension": item["extension"],
+            "thumbnail_url": item["thumbnail_url"],
+            "preview_url": item["preview_url"] if item["type"] == "raw" or item["type"] == "video" else None,
+            "image_url": item["image_url"] if item["type"] == "image" else None,
+            "video_url": item["video_url"] if item["type"] == "video" else None,
+            "raw_url": item["raw_url"] if item["type"] == "raw" else None,
+            "date": item["capture_date"],
+            "latitude": item["latitude"],
+            "longitude": item["longitude"],
+            "city": item["city"],
+            "state": item["state"],
+            "country": item["country"],
+            "width": item["width"],
+            "height": item["height"],
+            "duration": item["duration"],
+            "megapixels": item["megapixels"],
+            "metadata": {
+                "camera_make": item["camera_make"],
+                "camera_model": item["camera_model"],
+                "lens_make": item["lens_make"],
+                "lens_model": item["lens_model"],
+                "exposure_time": item["exposure_time"],
+                "f_number": item["f_number"],
+                "iso": item["iso"],
+                "focal_length": item["focal_length"],
+                "flash_fired": item["flash_fired"],
+                "size_bytes": item["file_size"],
+                "fps": item["fps"],
+                "codec": item["codec"],
+                "width": item["width"],
+                "height": item["height"],
+            }
+        }
+        for item in output if item["type"] == "raw"
+    ]
+    elif mediaFilter == "photos":
+        return [
+        {
+            "id": item["id"],
+            "score": item["score"],
+            "filename": item["filename"],
+            "is_favorite": item["is_favorite"],
+            "type": item["type"],
+            "extension": item["extension"],
+            "thumbnail_url": item["thumbnail_url"],
+            "preview_url": item["preview_url"] if item["type"] == "raw" or item["type"] == "video" else None,
+            "image_url": item["image_url"] if item["type"] == "image" else None,
+            "video_url": item["video_url"] if item["type"] == "video" else None,
+            "raw_url": item["raw_url"] if item["type"] == "raw" else None,
+            "date": item["capture_date"],
+            "latitude": item["latitude"],
+            "longitude": item["longitude"],
+            "city": item["city"],
+            "state": item["state"],
+            "country": item["country"],
+            "width": item["width"],
+            "height": item["height"],
+            "duration": item["duration"],
+            "megapixels": item["megapixels"],
+            "metadata": {
+                "camera_make": item["camera_make"],
+                "camera_model": item["camera_model"],
+                "lens_make": item["lens_make"],
+                "lens_model": item["lens_model"],
+                "exposure_time": item["exposure_time"],
+                "f_number": item["f_number"],
+                "iso": item["iso"],
+                "focal_length": item["focal_length"],
+                "flash_fired": item["flash_fired"],
+                "size_bytes": item["file_size"],
+                "fps": item["fps"],
+                "codec": item["codec"],
+                "width": item["width"],
+                "height": item["height"],
+            }
+        }
+        for item in output if item["type"] == "image"
+    ]
+    else:
+        return []

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -92,27 +92,42 @@ class Settings(BaseSettings):
     
     @property
     def THUMBNAIL_DIR(self):
-        os.makedirs(os.path.join(self.APP_DATA_DIR, "thumbnails"), exist_ok=True)
+        try:
+            os.makedirs(os.path.join(self.APP_DATA_DIR, "thumbnails"), exist_ok=True)
+        except Exception as e:
+            pass
         return os.path.join(self.APP_DATA_DIR, "thumbnails")
 
     @property
     def VIDEO_THUMBNAIL_DIR(self):
-        os.makedirs(os.path.join(self.APP_DATA_DIR, "video_thumbnails"), exist_ok=True)
+        try:
+            os.makedirs(os.path.join(self.APP_DATA_DIR, "video_thumbnails"), exist_ok=True)
+        except Exception as e:
+            pass
         return os.path.join(self.APP_DATA_DIR, "video_thumbnails")
 
     @property
     def VIDEO_PREVIEW_DIR(self):
-        os.makedirs(os.path.join(self.APP_DATA_DIR, "video_previews"), exist_ok=True)
+        try:
+            os.makedirs(os.path.join(self.APP_DATA_DIR, "video_previews"), exist_ok=True)
+        except Exception as e:
+            pass
         return os.path.join(self.APP_DATA_DIR, "video_previews")
     
     @property
     def RAW_THUMBNAIL_DIR(self):
-        os.makedirs(os.path.join(self.APP_DATA_DIR, "raw_thumbnails"), exist_ok=True)
+        try:
+            os.makedirs(os.path.join(self.APP_DATA_DIR, "raw_thumbnails"), exist_ok=True)
+        except Exception as e:
+            pass
         return os.path.join(self.APP_DATA_DIR, "raw_thumbnails")
     
     @property
     def RAW_PREVIEW_DIR(self):
-        os.makedirs(os.path.join(self.APP_DATA_DIR, "raw_previews"), exist_ok=True)
+        try:
+            os.makedirs(os.path.join(self.APP_DATA_DIR, "raw_previews"), exist_ok=True)
+        except Exception as e:
+            pass
         return os.path.join(self.APP_DATA_DIR, "raw_previews")
 
     class Config:

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -202,9 +202,9 @@ export const api = {
   // Favorites API ENDPOINTS
   // ------------------------------------------------------------
   // Fetch all favorites for timeline view
-  getAllFavoritesThumbnails: async (skip=0, limit=500) => {
+  getAllFavoritesThumbnails: async (skip=0, limit=500, mediaFilter="all") => {
     const response = await axios.get(`${API_URL}/favorites/timeline`, {
-      params: { skip: skip, limit: limit }
+      params: { skip: skip, limit: limit, mediaFilter: mediaFilter }
     });
     return {
       favorites: response.data,
@@ -265,9 +265,10 @@ export const api = {
   },
 
   // Search favorites
-  searchFavorites: async (query, skip=0, limit=500) => {
+  // Note: backend may ignore mediaFilter if not implemented server-side; frontend can still filter results.
+  searchFavorites: async (query, skip=0, limit=500, mediaFilter="all") => {
     const response = await axios.post(`${API_URL}/intelligence/search/favorites`, null, {
-      params: { query: query, skip: skip, limit: limit }
+      params: { query: query, skip: skip, limit: limit, mediaFilter: mediaFilter }
     });
     return {
       favorites: response.data,
@@ -308,9 +309,9 @@ export const api = {
   },
 
   // Search albums
-  searchAlbums: async (albumId, query, skip=0, limit=500) => {
+  searchAlbums: async (albumId, query, skip=0, limit=500, mediaFilter="all") => {
     const response = await axios.post(`${API_URL}/intelligence/search/albums/${albumId}`, null, {
-      params: { query: query, skip: skip, limit: limit }
+      params: { query: query, skip: skip, limit: limit, mediaFilter: mediaFilter }
     });
     return {
       albums: response.data,
@@ -412,9 +413,9 @@ export const api = {
     return response.data;
   },
 
-  getAlbumTimeline: async (albumId, skip=0, limit=500) => {
+  getAlbumTimeline: async (albumId, skip=0, limit=500, mediaFilter="all") => {
     const response = await axios.get(`${API_URL}/albums/timeline/${albumId}`, {
-      params: { skip: skip, limit: limit }
+      params: { skip: skip, limit: limit, mediaFilter: mediaFilter }
     });
     return {
       timeline: response.data,
@@ -547,10 +548,8 @@ export const api = {
     return response.data;
   },
 
-  getProcessedFilesInformation: async (path) => {
-    const response = await axios.get(`${API_URL}/dashboard/processed_files_information`, {
-      params: { path: path }
-    });
+  getProcessedFilesInformation: async () => {
+    const response = await axios.get(`${API_URL}/dashboard/processed_files_information`);
     return response.data;
   },
 

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -318,26 +318,9 @@ export default function Dashboard({ startVaultDownload, cancelVaultDownload, has
           setIsConnected(false);
         }
       } else {
+        setHavenVaultPath(null);
         setIsConfigured(false);
         setIsConnected(false);
-        setIsAppDataConfigured(false);
-        setIsAppDataConnected(false);
-        setHavenAppDataPath(null);
-        setTotalSize(0);
-        setUsedSize(0);
-        setAvailableSize(0);
-        setPercentage(0);
-        setImagesCount(0);
-        setVideosCount(0);
-        setRawCount(0);
-        setTotalFilesCount(0);
-        setImagesSize(0);
-        setVideosSize(0);
-        setRawSize(0);
-        setTotalFilesSize(0);
-        setLastChecked(new Date().toLocaleTimeString());
-        setIsRefreshing(false);
-        return;
       }
 
       const appDataPath = await api.getHotStoragePath();
@@ -399,7 +382,7 @@ export default function Dashboard({ startVaultDownload, cancelVaultDownload, has
         setRawSize(0);
         setTotalFilesSize(0);
       }
-      const processedFilesInformation = await api.getProcessedFilesInformation(storagePath);
+      const processedFilesInformation = await api.getProcessedFilesInformation();
       if (processedFilesInformation) {
         setAlbumsCount(processedFilesInformation.albums_count);
         setProcessedImagesCount(processedFilesInformation.processed_images_count);

--- a/frontend/src/components/RawImageGrid.jsx
+++ b/frontend/src/components/RawImageGrid.jsx
@@ -316,9 +316,9 @@ export default function RawImageGrid({
               Try searching for something else!
             </p>
           ) : (
-            <p className="text-slate-400 dark:text-white/30 text-sm mt-2">
-              Upload some RAW files to get started!
-            </p>
+          <p className="text-slate-400 dark:text-white/30 text-sm mt-2">
+            Upload some RAW files to get started!
+          </p>
           )}
         </div>
       </div>


### PR DESCRIPTION
This pull request adds support for filtering media by type (all, photos, videos, raw) across several API endpoints for albums, favorites, and semantic search. It also improves error handling in the dashboard endpoint and removes an unused parameter. The main changes focus on allowing clients to specify a `mediaFilter` parameter to retrieve only the desired types of media, and ensuring that counts and returned data reflect the filter.

**Media filtering enhancements:**

* Added a `mediaFilter` parameter to the `get_album_timeline`, `get_favorites_timeline`, and `search_favorites` endpoints, allowing clients to filter results by all, photos, videos, or raw media types. The filtering logic is applied to both the result set and the total count headers. (`backend/app/api/v1/endpoints/albums.py` [[1]](diffhunk://#diff-7e762fea03626ca763678dd5a8b2ba4e3daead06613f5a21ecbd99caeb5f024cR520) [[2]](diffhunk://#diff-7e762fea03626ca763678dd5a8b2ba4e3daead06613f5a21ecbd99caeb5f024cR559-R568) [[3]](diffhunk://#diff-7e762fea03626ca763678dd5a8b2ba4e3daead06613f5a21ecbd99caeb5f024cR632) [[4]](diffhunk://#diff-7e762fea03626ca763678dd5a8b2ba4e3daead06613f5a21ecbd99caeb5f024cR674-R804); `backend/app/api/v1/endpoints/favorites.py` [[5]](diffhunk://#diff-31671cd85b6d0e5a958a5800f79557903ba2fbc9e5661281680a7ff5126d3670R78) [[6]](diffhunk://#diff-31671cd85b6d0e5a958a5800f79557903ba2fbc9e5661281680a7ff5126d3670R112-R121) [[7]](diffhunk://#diff-31671cd85b6d0e5a958a5800f79557903ba2fbc9e5661281680a7ff5126d3670L174-R184) [[8]](diffhunk://#diff-31671cd85b6d0e5a958a5800f79557903ba2fbc9e5661281680a7ff5126d3670R226-R350); `backend/app/api/v1/endpoints/intelligence.py` [[9]](diffhunk://#diff-e7c0a042ab15d2e6b915acbca28bf58c62094e6642a4b358cb5d8f35e377569aL485-R485) [[10]](diffhunk://#diff-e7c0a042ab15d2e6b915acbca28bf58c62094e6642a4b358cb5d8f35e377569aR542-R551) [[11]](diffhunk://#diff-e7c0a042ab15d2e6b915acbca28bf58c62094e6642a4b358cb5d8f35e377569aR613)

**Dashboard endpoint improvements:**

* Removed the unused `path` parameter from the `get_processed_files_information` endpoint and replaced file existence checks with a try/except block for more robust error handling. Now, if an exception occurs, the endpoint returns `None` for all values instead of failing. (`backend/app/api/v1/endpoints/dashboard.py` [[1]](diffhunk://#diff-372fbb3939fdc3c17ce842273b9280adf2ae42a0bba94acc4075456b2494dc38L137-R142) [[2]](diffhunk://#diff-372fbb3939fdc3c17ce842273b9280adf2ae42a0bba94acc4075456b2494dc38R160-R168)

These updates provide more flexible and robust API endpoints for clients, allowing for more precise media queries and better error handling.